### PR TITLE
Add GitHub Skills activity to address issue #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program",
+        "schedule": "Ongoing, self-paced",
+        "max_participants": 50,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the extracurricular activities list, addressing issue #6. The activity is part of the GitHub Certifications program announced by the principal, with ongoing self-paced scheduling and capacity for 50 participants.